### PR TITLE
Fix and add some args

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ text-memorize
 
 A tool to help memorize some text!
 
-When provided with a file, this program will remove random words from each line of text and ask you to provide the words that were removed. You can provide lower and upper bounds to the number of words removed per line by using the `--l` and/or `--u` flags, or remove an exact number with `--n`
+When provided with a file, this program will remove random words from each line of text and ask you to provide the words that were removed.
 
-You can specify the number of attempts you want to allow with the `--a` flag. To turn off colors, just send in the `--no-color` flag.
+You can provide lower and upper bounds to the number of words removed per line by using the `--l` and/or `--u` flags, or remove an exact number with `--n`.  You can also specify the number of attempts you want to allow with the `--a` flag. To turn off colors, just send in the `--no-color` flag.
 
 text-memorize uses Python 2.7.
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,23 @@ text-memorize
 
 A tool to help memorize some text!
 
-When provided with a file, this program will remove random words from each line of text and ask you to provide the words that were removed.
+When provided with a file, this program will remove random words from each line of text and ask you to provide the words that were removed. You can provide lower and upper bounds to the number of words removed per line by using the `--l` and/or `--u` flags, or remove an exact number with `--n`
 
 You can specify the number of attempts you want to allow with the `--a` flag. To turn off colors, just send in the `--no-color` flag.
+
+text-memorize uses Python 2.7.
 
 ### How to run
 
 `python text_memorize.py filename`
+
+For between *i* and *j* words removed per line:
+
+`python text_memorize.py --l i --u j filename`
+
+For exactly *k* words removed per line:
+
+`python text_memorize.py --n k filename`
 
 For infinite attempts:
 

--- a/text_memorize.py
+++ b/text_memorize.py
@@ -17,6 +17,10 @@ parser.add_argument('--a', dest='tries', default=3,
                     help=('number of tries to allow per word '
                          '(0 for unlimited tries, default: 3)'))
 
+parser.add_argument('--n', dest='num', default=0,
+                    help=('number of words to remove from each line '
+                         '(0 for random number of removals, default: 0)'))
+
 parser.add_argument('filename', metavar='filename', type=str,
                     help='the text file')
 
@@ -29,9 +33,23 @@ try:
         for line in f:
             missing_words = []
             new_word = u''
+            split_line = line.split(' ')
 
-            for word in line.split(' '):
-                show_word = random.randrange(10) > 4
+            if int(args.num):
+                num = int(args.num)
+            else:
+                #num is in the range [1,len(split_line)], so at least
+                #one word will be removed.
+                num = random.randrange(len(split_line))+1
+
+            words = [False]*num
+            diff = len(split_line)-num
+            if diff > 0:
+                words.extend([True]*diff)
+                random.shuffle(words)
+
+            for i, word in enumerate(split_line):
+                show_word = words[i]
 
                 for char in word:
                     if (char.isalpha() and show_word) or not char.isalpha():

--- a/text_memorize.py
+++ b/text_memorize.py
@@ -81,7 +81,7 @@ try:
                 if len(new_word):
                     missing_words.append(new_word)
                     new_word = u''
-            tries = 0
+            tries = 1
 
             while len(missing_words):
                 
@@ -108,6 +108,6 @@ try:
                     current_line = current_line.replace('\033[91m_\033[0m' * len(next_word),next_word,1)
 
                 missing_words.pop(0)
-                tries = 0
+                tries = 1
 except IOError:
     print("File not found: '{}'".format(args.filename))

--- a/text_memorize.py
+++ b/text_memorize.py
@@ -47,16 +47,16 @@ try:
                 num = args.num
             else:
                 if args.upper:
-                    upper = args.upper+1
+                    upper = args.upper + 1
                 else:
-                    upper = len(split_line)+1
+                    upper = len(split_line) + 1
 
                 num = random.randrange(start=args.lower, stop=upper)
 
-            words = [False]*num
-            diff = len(split_line)-num
+            words = [False] * num
+            diff = len(split_line) - num
             if diff > 0:
-                words.extend([True]*diff)
+                words.extend([True] * diff)
                 random.shuffle(words)
 
             for i, word in enumerate(split_line):

--- a/text_memorize.py
+++ b/text_memorize.py
@@ -13,19 +13,19 @@ each line of text and ask you to provide the words that were removed.""")
 parser.add_argument('--no-color', action='store_true',
                     help='hide colorful underlining')
 
-parser.add_argument('--a', dest='tries', default=3,
+parser.add_argument('--a', dest='tries', type=int, default=3,
                     help=('number of tries to allow per word '
                          '(0 for unlimited tries, default: 3)'))
 
-parser.add_argument('--n', dest='num', default=0,
+parser.add_argument('--n', dest='num', type=int, default=0,
                     help=('number of words to remove from each line '
                          '(0 for random number of removals, default: 0)'))
 
-parser.add_argument('--l', dest='lower', default=1,
+parser.add_argument('--l', dest='lower', type=int, default=1,
                     help=('lower bound on number of words to remove '
                          '(inclusive, default: 1)'))
 
-parser.add_argument('--u', dest='upper', default=0,
+parser.add_argument('--u', dest='upper', type=int, default=0,
                     help=('upper bound on number of words to remove '
                          '(inclusive, 0 for no upper bound, default: 0)'))
 
@@ -43,15 +43,15 @@ try:
             new_word = u''
             split_line = line.split(' ')
 
-            if int(args.num):
-                num = int(args.num)
+            if args.num:
+                num = args.num
             else:
                 if args.upper:
-                    upper = int(args.upper)+1
+                    upper = args.upper+1
                 else:
                     upper = len(split_line)+1
 
-                num = random.randrange(start=int(args.lower), stop=upper)
+                num = random.randrange(start=args.lower, stop=upper)
 
             words = [False]*num
             diff = len(split_line)-num

--- a/text_memorize.py
+++ b/text_memorize.py
@@ -21,6 +21,14 @@ parser.add_argument('--n', dest='num', default=0,
                     help=('number of words to remove from each line '
                          '(0 for random number of removals, default: 0)'))
 
+parser.add_argument('--l', dest='lower', default=1,
+                    help=('lower bound on number of words to remove '
+                         '(inclusive, default: 1)'))
+
+parser.add_argument('--u', dest='upper', default=0,
+                    help=('upper bound on number of words to remove '
+                         '(inclusive, 0 for no upper bound, default: 0)'))
+
 parser.add_argument('filename', metavar='filename', type=str,
                     help='the text file')
 
@@ -38,9 +46,12 @@ try:
             if int(args.num):
                 num = int(args.num)
             else:
-                #num is in the range [1,len(split_line)], so at least
-                #one word will be removed.
-                num = random.randrange(len(split_line))+1
+                if args.upper:
+                    upper = int(args.upper)+1
+                else:
+                    upper = len(split_line)+1
+
+                num = random.randrange(start=int(args.lower), stop=upper)
 
             words = [False]*num
             diff = len(split_line)-num


### PR DESCRIPTION
I added some additional flags:
- `--l` and `--u`: Lower and upper bounds to the number of words removed per line.
- `--n`: An exact number of words to remove per line.

May be "out of scope" for what you're going for, but these changes made using the program a bit more comfortable for me.

The `--a` flag did not seem to function as intended and so I made a few adjustments.  Inputs to it are now properly converted to integers and afford the proper number of tries.

These changes come with modifications to the way that removed words are chosen, so you may notice some differences in the number of words removed when running text-memorize (e.g., it being more likely for all words on a line to be removed), especially without any flags.  This could be addressed with some sort of probability flag, but I settled on allowing lower and upper bounds instead.
